### PR TITLE
Suppress NSME caused by isJavaDebuggable on 8.1

### DIFF
--- a/lsplant/src/main/jni/common.hpp
+++ b/lsplant/src/main/jni/common.hpp
@@ -55,6 +55,10 @@ inline auto GetAndroidApiLevel() {
 
 inline auto IsJavaDebuggable(JNIEnv *env) {
     static auto kDebuggable = [&env]() {
+        auto sdk_int = GetAndroidApiLevel();
+        if (sdk_int < __ANDROID_API_P__) {
+            return false;
+        }
         auto runtime_class = JNI_FindClass(env, "dalvik/system/VMRuntime");
         if (!runtime_class) {
             LOGE("Failed to find VMRuntime");


### PR DESCRIPTION
This API is only available since Android P.

```
[ 2022-04-06T11:58:31.331    10172:  6311:  6311 E/LSPosed         ] java.lang.NoSuchMethodError: no non-static method "Ldalvik/system/VMRuntime;.isJavaDebuggable()Z"
	at com.android.internal.os.Zygote.nativeForkAndSpecialize(Native Method)
	at com.android.internal.os.Zygote.forkAndSpecialize(Zygote.java:105)
	at com.android.internal.os.ZygoteConnection.processOneCommand(ZygoteConnection.java:222)
	at com.android.internal.os.ZygoteServer.runSelectLoop(ZygoteServer.java:174)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:813)
[ 2022-04-06T11:58:31.331    10172:  6311:  6311 E/LSPlant         ] Failed to find VMRuntime.isJavaDebuggable()
```