### PR TITLE
Fix some symbols not found in riscv64

### DIFF
--- a/lsplant/src/main/jni/CMakeLists.txt
+++ b/lsplant/src/main/jni/CMakeLists.txt
@@ -17,7 +17,11 @@ if (LSPLANT_STANDALONE)
     link_libraries(cxx::cxx)
 endif()
 
-set(SOURCES lsplant.cc lsplant_asm.S)
+set(SOURCES lsplant.cc)
+if (CMAKE_ANDROID_ARCH_ABI MATCHES "^(arm64-v8a|riscv64)$")
+    set(SOURCES ${SOURCES} lsplant_asm.S)
+endif ()
+
 file(GLOB_RECURSE MODULE_SOURCES CONFIGURE_DEPENDS "*.cxx")
 file(GLOB_RECURSE MODULE_INTERFACES CONFIGURE_DEPENDS "*.ixx")
 list(FILTER MODULE_SOURCES EXCLUDE REGEX "${PROJECT_SOURCE_DIR}.external.+")

--- a/lsplant/src/main/jni/CMakeLists.txt
+++ b/lsplant/src/main/jni/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.28)
 project(lsplant)
 
+enable_language(ASM)
+
 find_program(CCACHE ccache)
 
 set(CMAKE_CXX_STANDARD 23)
@@ -15,7 +17,7 @@ if (LSPLANT_STANDALONE)
     link_libraries(cxx::cxx)
 endif()
 
-set(SOURCES lsplant.cc)
+set(SOURCES lsplant.cc lsplant_asm.S)
 file(GLOB_RECURSE MODULE_SOURCES CONFIGURE_DEPENDS "*.cxx")
 file(GLOB_RECURSE MODULE_INTERFACES CONFIGURE_DEPENDS "*.ixx")
 list(FILTER MODULE_SOURCES EXCLUDE REGEX "${PROJECT_SOURCE_DIR}.external.+")

--- a/lsplant/src/main/jni/art/runtime/class_linker.cxx
+++ b/lsplant/src/main/jni/art/runtime/class_linker.cxx
@@ -2,6 +2,8 @@ module;
 
 #include <sys/types.h>
 
+#include <array>
+
 #include "logging.hpp"
 
 export module class_linker;

--- a/lsplant/src/main/jni/include/utils/hook_helper.hpp
+++ b/lsplant/src/main/jni/include/utils/hook_helper.hpp
@@ -130,6 +130,8 @@ struct Function<Sym, Ret(Args...)> {
     [[gnu::always_inline]] operator bool() { return function_ != nullptr; }
     auto operator&() const { return function_; }
 
+    void update(void *new_value) { function_ = reinterpret_cast<Ret (*)(Args...)>(new_value); }
+
 private:
     friend struct HookHandler;
     Ret (*function_)(Args...) = nullptr;

--- a/lsplant/src/main/jni/lsplant_asm.S
+++ b/lsplant/src/main/jni/lsplant_asm.S
@@ -1,0 +1,104 @@
+    .text
+    .global lsplant_get_trampoline_address
+    .hidden lsplant_get_trampoline_address
+    .type   lsplant_get_trampoline_address, @function
+lsplant_get_trampoline_address:
+// void* (*)(const ClassLinker* class_linker, bool (*checker)(const ClassLinker*, const void*))
+    .cfi_startproc
+
+#if defined(__riscv)
+
+    addi    sp, sp, -88
+    sd      ra, 80(sp)
+    sd      s0, 72(sp)
+    sd      s1, 64(sp)
+    sd      s2, 56(sp)
+
+    mv      s0, a0  // class_linker
+    mv      s1, a1  // checker
+    jalr    s1
+
+    sd      a1, 40(sp)
+    sd      a2, 48(sp)  // It might be this register
+    sd      a3, 32(sp)
+    sd      a4, 24(sp)
+    sd      a5, 16(sp)
+    sd      a6, 8(sp)
+    sd      a7, 0(sp)
+
+    addi    s2, sp, 48
+.L.loop:
+    mv      a0, s0
+    ld      a1, 0(s2)
+    beqz    a1, .L.continue
+    jalr    s1
+    bnez    a0, .L.found
+    beq     s2, sp, .L.break
+.L.continue:
+    addi    s2, s2, -8
+    j       .L.loop
+.L.break:
+    li      a0, 0
+    j       .L.pop
+
+.L.found:
+    ld      a0, 0(s2)
+
+.L.pop:
+    ld      ra, 80(sp)
+    ld      s0, 72(sp)
+    ld      s1, 64(sp)
+    ld      s2, 56(sp)
+    addi    sp, sp, 88
+    ret
+
+#elif defined(__aarch64__)
+
+    sub     sp, sp, #112
+    stp     fp, lr, [sp, #64]
+    stp     x21, x22, [sp, #80]
+    stp     x19, x20, [sp, #96]
+    add     fp, sp, #64
+
+    mov     x19, x0  // class_linker
+    mov     x20, x1  // checker
+    blr     x20
+
+    stp     x8, x9, [sp, #48]  // It might be x9 register
+    stp     x10, x11, [sp, #32]
+    stp     x12, x13, [sp, #16]
+    stp     x14, x15, [sp, #0]
+
+    add     x21, sp, #56
+    mov     x22, sp
+.L.loop:
+    mov     x0, x19
+    ldr     x1, [x21, #0]
+    cbz     x1, .L.continue
+    blr     x20
+    cbnz    x0, .L.found
+    cmp     x21, x22
+    b.eq    .L.break
+.L.continue:
+    sub     x21, x21, #8
+    b       .L.loop
+.L.break:
+    mov     x0, xzr
+    b       .L.pop
+
+.L.found:
+    ldr     x0, [x21, #0]
+
+.L.pop:
+    ldp     x19, x20, [sp, #96]
+    ldp     x21, x22, [sp, #80]
+    ldp     fp, lr, [sp, #64]
+    add     sp, sp, #112
+    ret
+
+#else
+#error unsupported
+#endif
+
+    .cfi_endproc
+    .size   lsplant_get_trampoline_address, .-lsplant_get_trampoline_address


### PR DESCRIPTION
The symbols `art_quick_generic_jni_trampoline` and `art_quick_to_interpreter_bridge` no longer exist in baklava riscv64, so I found another way to lookup the addresses of these two symbols.
![405334995-883710c9-bbca-4feb-a532-01d181ee4bbf](https://github.com/user-attachments/assets/7fa2ab8f-a17b-470c-b297-dac8b4efd926)
