### PR TITLE
Fix the SIGSEGV caused by premature initialization of ClassLinker

### DIFF
--- a/lsplant/src/main/jni/lsplant.cc
+++ b/lsplant/src/main/jni/lsplant.cc
@@ -268,12 +268,12 @@ bool InitNative(JNIEnv *env, const HookHandler &handler) {
         LOGE("Failed to init thread");
         return false;
     }
-    if (!ClassLinker::Init(handler)) {
-        LOGE("Failed to init class linker");
-        return false;
-    }
     if (!Class::Init(handler)) {
         LOGE("Failed to init mirror class");
+        return false;
+    }
+    if (!ClassLinker::Init(handler)) {
+        LOGE("Failed to init class linker");
         return false;
     }
     if (!ScopedSuspendAll::Init(handler)) {


### PR DESCRIPTION
ClassLinker should be initialized after Class because FixupStaticTrampolines references Class::GetClassDef, causing a SIGSEGV.