### PR TITLE
Fix jit crash caused by hooking intrinsic methods in bootclasspath on Android 15 and above

### DIFF
--- a/lsplant/src/main/jni/art/runtime/art_method.cxx
+++ b/lsplant/src/main/jni/art/runtime/art_method.cxx
@@ -308,6 +308,7 @@ public:
             kAccPreCompiled = 0x00800000;
         }
         if (sdk_int < __ANDROID_API_Q__) kAccFastInterpreterToInterpreterInvoke = 0;
+        if (sdk_int < __ANDROID_API_O__) kAccIntrinsic = 0;
 
         if (!handler(GetMethodShortyL_, true, GetMethodShorty_)) {
             LOGE("Failed to find GetMethodShorty");
@@ -318,8 +319,6 @@ public:
 
         if (sdk_int >= __ANDROID_API_O__) [[likely]] {
             handler(SetNotIntrinsic_);
-        } else {
-            kAccIntrinsic = 0;
         }
 
         if (sdk_int <= __ANDROID_API_O__) [[unlikely]] {

--- a/lsplant/src/main/jni/art/runtime/art_method.cxx
+++ b/lsplant/src/main/jni/art/runtime/art_method.cxx
@@ -316,8 +316,10 @@ public:
 
         handler(PrettyMethod_, PrettyMethodStatic_, PrettyMethodMirror_);
 
-        if (sdk_int >= __ANDROID_API_O__) {
+        if (sdk_int >= __ANDROID_API_O__) [[likely]] {
             handler(SetNotIntrinsic_);
+        } else {
+            kAccIntrinsic = 0;
         }
 
         if (sdk_int <= __ANDROID_API_O__) [[unlikely]] {

--- a/lsplant/src/main/jni/lsplant.cc
+++ b/lsplant/src/main/jni/lsplant.cc
@@ -539,9 +539,7 @@ bool DoHook(ArtMethod *target, ArtMethod *hook, ArtMethod *backup) {
     } else {
         LOGV("Generated trampoline %p", entrypoint);
 
-        if (GetAndroidApiLevel() >= __ANDROID_API_O__ && target->IsIntrinsic()) [[unlikely]] {
-            target->SetNonIntrinsic();
-        }
+        target->SetNonIntrinsic();
 
         hook->SetNonCompilable();
 

--- a/lsplant/src/main/jni/lsplant.cc
+++ b/lsplant/src/main/jni/lsplant.cc
@@ -539,6 +539,10 @@ bool DoHook(ArtMethod *target, ArtMethod *hook, ArtMethod *backup) {
     } else {
         LOGV("Generated trampoline %p", entrypoint);
 
+        if (GetAndroidApiLevel() >= __ANDROID_API_O__ && target->IsIntrinsic()) [[unlikely]] {
+            target->SetNonIntrinsic();
+        }
+
         hook->SetNonCompilable();
 
         target->BackupTo(backup);


### PR DESCRIPTION
This only happens on Android 15 and above, you can see [intrinsics_list.h](https://cs.android.com/android/platform/superproject/main/+/main:art/runtime/intrinsics_list.h) and [instruction_builder.cc](https://cs.android.com/android/platform/superproject/main/+/main:art/compiler/optimizing/instruction_builder.cc;l=1165)

```
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0000000000000030
Cause: null pointer dereference
    x0  0000000000000000  x1  0000000000000002  x2  000000704ebe41e8  x3  0000006d8f97ed9d
    x4  000000704ebe4420  x5  0000000000000004  x6  0000006d8099d470  x7  7f7f7f7f7f7f7f7f
    x8  0000000000000010  x9  0000000000000020  x10 0000000000000019  x11 0000006d93a0ea80
    x12 0000006d9308d020  x13 000000000000001c  x14 0000000000000000  x15 0000000000000008
    x16 0000006d93a24d48  x17 000000703949a8c0  x18 0000006d7c2f4000  x19 000000704ebe41e8
    x20 000000704ebe23a0  x21 0000000000000002  x22 000000704ebe42b8  x23 0000000000000001
    x24 0000000000000000  x25 0000000000000000  x26 0000000000000000  x27 000000704ebe4498
    x28 0000000000000000  x29 0000006d8099d370
    lr  0000006d933361d0  sp  0000006d8099d370  pc  0000006d93336164  pst 0000000080001000

14 total frames
backtrace:
      #00 pc 0000000000336164  /apex/com.android.art/lib64/libart.so (art::Add(art::HInstructionList*, art::HBasicBlock*, art::HInstruction*) (.__uniq.147252545582089978308689827824377933333.llvm.7446156075945506185)+116) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #01 pc 00000000002efcc8  /apex/com.android.art/lib64/libart.so (art::HInstructionBuilder::BuildInvoke(art::Instruction const&, unsigned int, unsigned int, art::InstructionOperands const&)+5772) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #02 pc 00000000002e8f44  /apex/com.android.art/lib64/libart.so (art::HInstructionBuilder::ProcessDexInstruction(art::Instruction const&, unsigned int)+288) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #03 pc 00000000002e83d8  /apex/com.android.art/lib64/libart.so (art::HInstructionBuilder::Build()+2804) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #04 pc 00000000002b0f1c  /apex/com.android.art/lib64/libart.so (art::HGraphBuilder::BuildGraph()+424) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #05 pc 000000000034b4c8  /apex/com.android.art/lib64/libart.so (art::OptimizingCompiler::TryCompile(art::ArenaAllocator*, art::ArenaStack*, art::DexCompilationUnit const&, art::ArtMethod*, art::CompilationKind, art::VariableSizedHandleScope*) const+3176) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #06 pc 000000000034f220  /apex/com.android.art/lib64/libart.so (art::OptimizingCompiler::JitCompile(art::Thread*, art::jit::JitCodeCache*, art::jit::JitMemoryRegion*, art::ArtMethod*, art::CompilationKind, art::jit::JitLogger*)+1276) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #07 pc 000000000029c54c  /apex/com.android.art/lib64/libart.so (art::jit::JitCompiler::CompileMethod(art::Thread*, art::jit::JitMemoryRegion*, art::ArtMethod*, art::CompilationKind)+636) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #08 pc 000000000060d0c8  /apex/com.android.art/lib64/libart.so (art::jit::Jit::CompileMethodInternal(art::ArtMethod*, art::Thread*, art::CompilationKind, bool)+1024) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #09 pc 0000000000618d54  /apex/com.android.art/lib64/libart.so (art::jit::JitCompileTask::Run(art::Thread*)+540) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #10 pc 00000000008aa424  /apex/com.android.art/lib64/libart.so (art::ThreadPoolWorker::Run()+300) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #11 pc 00000000008a9e34  /apex/com.android.art/lib64/libart.so (art::ThreadPoolWorker::Callback(void*)+180) (BuildId: f09f55f58888db3fa9c586c60e5e1385)
      #12 pc 0000000000072114  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+196) (BuildId: c39f57777755022581a2d51ce7f3bb68)
      #13 pc 0000000000064230  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+68) (BuildId: c39f57777755022581a2d51ce7f3bb68)
```