### PR TITLE
Allow initialization with stripped instrumentation symbols

### DIFF
--- a/lsplant/src/main/jni/art/runtime/instrumentation.cxx
+++ b/lsplant/src/main/jni/art/runtime/instrumentation.cxx
@@ -65,7 +65,11 @@ public:
         int sdk_int = GetAndroidApiLevel();
         if (sdk_int >= kSdkPie) [[likely]] {
             if (!handler(ReinitializeMethodsCode_, InitializeMethodsCode_, UpdateMethodsCodeToInterpreterEntryPoint_)) {
-                return false;
+                // Some userdebug ART builds strip every debuggable-only code-update symbol.
+                // InitNative forces the runtime non-debuggable after initialization, which also
+                // prevents ART from resetting hooked method entrypoints.
+                LOGW("Instrumentation code-update hooks unavailable; relying on the "
+                     "non-debuggable runtime workaround");
             }
         }
         return true;


### PR DESCRIPTION
## What changed

Treat missing debuggable-only instrumentation code-update symbols as non-fatal during initialization.

## Why

Some API 36 userdebug ART builds expose the runtime as Java-debuggable while stripping all supported
`Instrumentation` code-update symbols. Initialization currently aborts in that case, even though
`InitNative` immediately forces the runtime non-debuggable after the remaining initialization steps.
That runtime transition provides the same protection against ART resetting hooked method entrypoints.

## Impact

Ordinary user builds and userdebug builds with any supported instrumentation symbol are unchanged.
Affected userdebug builds can initialize successfully and emit a warning explaining the fallback.

## Validation

- `git diff --check`
- Equivalent v6.4 backport compiled as part of an Android arm64 native integration
- Behavior previously verified on an API 36 userdebug runtime where all three symbols were absent
