### PR TITLE
Fix `art_symbol_prefix_resolver` docs

### DIFF
--- a/lsplant/src/main/jni/include/lsplant.hpp
+++ b/lsplant/src/main/jni/include/lsplant.hpp
@@ -59,8 +59,7 @@ struct InitInfo {
     InlineUnhookFunType inline_unhooker;
     /// \brief The symbol resolver to \p libart.so. Must not be null.
     ArtSymbolResolver art_symbol_resolver;
-
-    /// \brief The symbol prefix resolver to \p libart.so. May be null.
+    /// \brief The symbol prefix resolver to \p libart.so. Must not be null.
     ArtSymbolPrefixResolver art_symbol_prefix_resolver;
 
     /// \brief The generated class name. Must not be empty. It contains a field and a method

--- a/lsplant/src/main/jni/lsplant.cc
+++ b/lsplant/src/main/jni/lsplant.cc
@@ -800,6 +800,7 @@ using ::lsplant::IsHooked;
 [[maybe_unused]] bool Init(JNIEnv *env, const InitInfo &info) {
     if (!info.inline_hooker || !info.inline_unhooker || !info.art_symbol_resolver ||
         !info.art_symbol_prefix_resolver) {
+        LOGE("Invalid init info");
         return false;
     }
     bool static kInit = InitConfig(info) && InitJNI(env) && InitNative(env, info);


### PR DESCRIPTION
art_symbol_prefix_resolver is flaged as "May be null" but LSPlant::Init mandates it to not be null, this can cause confusion.