### PR TITLE
Initialize CloseGuard for legacy synthetic DexFiles

### DIFF
--- a/lsplant/src/main/jni/art/runtime/dex_file.cxx
+++ b/lsplant/src/main/jni/art/runtime/dex_file.cxx
@@ -66,6 +66,17 @@ public:
 
     jobject ToJavaDexFile(JNIEnv* env) const {
         auto* java_dex_file = env->AllocObject(dex_file_class);
+        if (!java_dex_file) [[unlikely]] {
+            return nullptr;
+        }
+        auto close_guard =
+            JNI_CallStaticObjectMethod(env, close_guard_class, close_guard_get);
+        if (!close_guard) [[unlikely]] {
+            LOGE("Failed to initialize DexFile CloseGuard");
+            env->DeleteLocalRef(java_dex_file);
+            return nullptr;
+        }
+        JNI_SetObjectField(env, java_dex_file, close_guard_field, close_guard);
         auto cookie = JNI_NewLongArray(env, dex_file_start_index + 1);
         if (dex_file_start_index != size_t(-1)) [[likely]] {
             cookie[oat_file_index] = 0;
@@ -108,6 +119,19 @@ public:
         if (!dex_file_class) [[unlikely]] {
             return false;
         }
+        close_guard_class =
+            JNI_NewGlobalRef(env, JNI_FindClass(env, "dalvik/system/CloseGuard"));
+        if (!close_guard_class) [[unlikely]] {
+            return false;
+        }
+        close_guard_get =
+            JNI_GetStaticMethodID(env, close_guard_class, "get",
+                                  "()Ldalvik/system/CloseGuard;");
+        close_guard_field =
+            JNI_GetFieldID(env, dex_file_class, "guard", "Ldalvik/system/CloseGuard;");
+        if (!close_guard_get || !close_guard_field) [[unlikely]] {
+            return false;
+        }
         if (sdk_int >= kSdkMarshmallow) [[unlikely]] {
             cookie_field = JNI_GetFieldID(env, dex_file_class, "mCookie", "Ljava/lang/Object;");
         } else {
@@ -134,6 +158,9 @@ public:
 
 private:
     inline static jclass dex_file_class = nullptr;
+    inline static jclass close_guard_class = nullptr;
+    inline static jmethodID close_guard_get = nullptr;
+    inline static jfieldID close_guard_field = nullptr;
     inline static jfieldID cookie_field = nullptr;
     inline static jfieldID file_name_field = nullptr;
     inline static jfieldID internal_cookie_field = nullptr;


### PR DESCRIPTION
### Problem

The pre-Android O generated-dex fallback allocates `dalvik.system.DexFile` with `AllocObject` so
it can attach an in-memory ART dex. On API 21-25 this bypasses the constructor's initialization of
the private `CloseGuard guard` field. Finalization later calls `close()` and throws a
`NullPointerException` from `CloseGuard.close()`.

### Fix

Resolve `CloseGuard.get()` and the legacy `DexFile.guard` field during `DexFile::Init`, then seed a
fresh guard on every synthetic object returned by `ToJavaDexFile`. If any framework contract is
missing, initialization fails closed and LSPlant remains unavailable on that runtime.

### Evidence

- HookBridge ARM64 release native build passes.
- A source contract regression test covers class/method/field lookup and object seeding.
- With the fix enabled on an API 21 ARM64 emulator, LSPlant initialized and installed its hooks;
  the six fixture logs contained no `DexFile.finalize`/`CloseGuard.close` NPEs. The broader fixture
  harness still reported no-bound rows, so this is not presented as a complete compatibility pass.
